### PR TITLE
EventEmitter実装の完成と拡張 (Issue #3)

### DIFF
--- a/src/utils/EventEmitter.js
+++ b/src/utils/EventEmitter.js
@@ -79,6 +79,23 @@ class EventEmitter {
   listenerCount(event) {
     return this._events[event] ? this._events[event].length : 0;
   }
+  
+  /**
+   * すべてのイベントリスナーを解除します
+   * @return {EventEmitter} - メソッドチェーン用のインスタンス自身
+   */
+  removeAllListeners() {
+    this._events = {};
+    return this;
+  }
+  
+  /**
+   * 登録されているすべてのイベント名を配列で返します
+   * @return {Array<string>} - イベント名の配列
+   */
+  eventNames() {
+    return Object.keys(this._events);
+  }
 }
 
 export default EventEmitter;

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -33,6 +33,13 @@ const myListener = (data) => console.log(data);
 emitter.on('customEvent', myListener);
 emitter.off('customEvent', myListener); // 特定のリスナーを削除
 emitter.off('customEvent'); // そのイベントのすべてのリスナーを削除
+
+// すべてのイベントリスナーを削除
+emitter.removeAllListeners();
+
+// 登録されているイベント名を取得
+const eventNames = emitter.eventNames();
+console.log('登録されているイベント:', eventNames);
 ```
 
 ## EventTypes

--- a/tests/utils/EventEmitter.test.js
+++ b/tests/utils/EventEmitter.test.js
@@ -94,6 +94,39 @@ describe('EventEmitter', () => {
     emitter.off('testEvent');
     expect(emitter.listenerCount('testEvent')).toBe(0);
   });
+
+  test('should remove all listeners', () => {
+    const mockCallback1 = jest.fn();
+    const mockCallback2 = jest.fn();
+    const mockCallback3 = jest.fn();
+    
+    emitter.on('event1', mockCallback1);
+    emitter.on('event2', mockCallback2);
+    emitter.on('event3', mockCallback3);
+    
+    emitter.removeAllListeners();
+    
+    emitter.emit('event1');
+    emitter.emit('event2');
+    emitter.emit('event3');
+    
+    expect(mockCallback1).not.toHaveBeenCalled();
+    expect(mockCallback2).not.toHaveBeenCalled();
+    expect(mockCallback3).not.toHaveBeenCalled();
+  });
+  
+  test('should return all event names', () => {
+    emitter.on('event1', () => {});
+    emitter.on('event2', () => {});
+    emitter.on('event3', () => {});
+    
+    const eventNames = emitter.eventNames();
+    
+    expect(eventNames).toContain('event1');
+    expect(eventNames).toContain('event2');
+    expect(eventNames).toContain('event3');
+    expect(eventNames.length).toBe(3);
+  });
 });
 
 describe('EventTypes integration with EventEmitter', () => {


### PR DESCRIPTION
## 概要
Issue #3 で要求されたEventEmitterの実装を完成させました。既存の実装を拡張し、全てのイベントリスナーを一度に削除する`removeAllListeners`メソッドと、登録済みのイベント名を取得する`eventNames`メソッドを追加しました。

## 変更内容
- EventEmitterに以下のメソッドを追加
  - `removeAllListeners()`: すべてのイベントリスナーを一度に削除
  - `eventNames()`: 登録されているイベント名の一覧を取得
- 追加したメソッドのテストケースを実装
- READMEに追加機能の使用例を記載

## テスト
- 新しいテストケースを追加し、すべて正常に動作することを確認しました

## 関連Issue
- Closes #3